### PR TITLE
Claude/extend mechanism 011 cv4dgfsonx bvae ppc wl np

### DIFF
--- a/ENCODINGS.md
+++ b/ENCODINGS.md
@@ -1,0 +1,436 @@
+# Extending Data Codings in node-smpp
+
+This guide explains how to extend the node-smpp library with custom data codings and character encodings.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Registering Custom Encodings](#registering-custom-encodings)
+- [Registering Custom GSM Coders](#registering-custom-gsm-coders)
+- [Built-in Encodings](#built-in-encodings)
+- [Examples](#examples)
+
+## Overview
+
+The node-smpp library provides a flexible mechanism for extending data codings. You can:
+
+1. **Register custom encodings** - Add support for new character encodings (e.g., UTF-8, custom codepages)
+2. **Register custom GSM coders** - Add support for new GSM 03.38 shift tables (e.g., language-specific character sets)
+
+## Registering Custom Encodings
+
+Use the `registerEncoding()` function to add a new encoding to the library.
+
+### API
+
+```typescript
+smpp.registerEncoding(name: string, encoding: Encoding): void
+```
+
+**Parameters:**
+- `name` - The name of the encoding (e.g., 'UTF8', 'CUSTOM')
+- `encoding` - An object implementing the `Encoding` interface:
+  - `match(value: string): boolean` - Returns true if the value can be encoded with this encoding
+  - `encode(value: string): Buffer` - Encodes a string to a Buffer
+  - `decode(value: Buffer | string): string` - Decodes a Buffer to a string
+
+### Example: UTF-8 Encoding
+
+```javascript
+const smpp = require('smpp');
+
+// Register UTF-8 encoding
+smpp.registerEncoding('UTF8', {
+  match: (value) => {
+    // UTF-8 can encode any string
+    return true;
+  },
+  encode: (value) => {
+    return Buffer.from(value, 'utf8');
+  },
+  decode: (value) => {
+    if (Buffer.isBuffer(value)) {
+      return value.toString('utf8');
+    }
+    return String(value);
+  }
+});
+
+// Use it in your SMPP session
+const session = smpp.connect('smpp://localhost:2775');
+
+session.submit_sm({
+  destination_addr: '1234567890',
+  short_message: {
+    message: 'Hello 世界 🌍',
+    udh: null
+  },
+  data_coding: 0x08 // Or use smpp.ENCODING.UCS2
+}, (pdu) => {
+  console.log('Message sent:', pdu);
+});
+```
+
+### Example: ISO-8859-2 (Latin-2) Encoding
+
+```javascript
+const smpp = require('smpp');
+const iconv = require('iconv-lite');
+
+// Register ISO-8859-2 encoding for Central European languages
+smpp.registerEncoding('LATIN2', {
+  match: (value) => {
+    // Check if value can be encoded as Latin-2
+    return value === iconv.decode(iconv.encode(value, 'latin2'), 'latin2');
+  },
+  encode: (value) => {
+    return iconv.encode(value, 'latin2');
+  },
+  decode: (value) => {
+    return iconv.decode(value, 'latin2');
+  }
+});
+
+// Add to constants for easier reference
+smpp.consts.ENCODING.LATIN2 = 0x10; // Custom data_coding value
+
+// Set as default encoding
+smpp.encodings.default = 'LATIN2';
+```
+
+## Registering Custom GSM Coders
+
+Use the `registerGsmCoder()` function to add new GSM 03.38 shift tables.
+
+### API
+
+```typescript
+smpp.registerGsmCoder(
+  name: string,
+  encodingValue: number,
+  coderDef: GsmCoderDefinition
+): void
+```
+
+**Parameters:**
+- `name` - The name of the GSM coder (e.g., 'GSM_FR', 'GSM_DE')
+- `encodingValue` - The encoding value (0x00-0xFF) used in UDH headers
+- `coderDef` - An object implementing the `GsmCoderDefinition` interface:
+  - `chars: string` - Standard character set (128 characters)
+  - `extChars?: string` - Extended characters (escaped with 0x1B)
+  - `escChars?: string` - Escape characters
+  - `charRegex: RegExp` - Validation regex for the character set
+  - `charListEnc: {}` - Character lookup table for encoding (initialized automatically)
+  - `extCharListEnc: {}` - Extended character lookup table for encoding
+  - `charListDec: {}` - Character lookup table for decoding
+  - `extCharListDec: {}` - Extended character lookup table for decoding
+
+### Example: GSM French Shift Table
+
+```javascript
+const smpp = require('smpp');
+
+// Register a hypothetical French GSM shift table
+smpp.registerGsmCoder('GSM_FR', 0x04, {
+  chars:
+    '@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞ\x1BÆæßÉ !"#¤%&\'()*+,-./0123456789:;<=>?¡ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÑÜ§¿abcdefghijklmnopqrstuvwxyzäöñüà',
+  extChars: '\f^{}\\[~]|€àâêîô',
+  escChars: '\nΛ()/<=>¡eaaaeo',
+  charRegex: /^[@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞ\x1BÆæßÉ !"#¤%&\'()*+,\-./0-9:;<=>?¡A-ZÄÖÑÜ§¿a-zäöñüà\f^{}\\[~\]|€àâêîô]*$/,
+  charListEnc: {},
+  extCharListEnc: {},
+  charListDec: {},
+  extCharListDec: {}
+});
+
+// Add to constants
+smpp.consts.ENCODING.GSM_FR = 0x01;
+
+// Use with UDH for language-specific encoding
+session.submit_sm({
+  destination_addr: '1234567890',
+  short_message: {
+    message: 'Bonjour! Comment ça va?',
+    udh: Buffer.from([0x25, 0x01, 0x04]) // 0x25 = locking shift, 0x04 = French
+  },
+  data_coding: 0x00 // GSM default
+}, (pdu) => {
+  console.log('Message sent:', pdu);
+});
+```
+
+### Example: GSM German Shift Table
+
+```javascript
+const smpp = require('smpp');
+
+// Register German GSM shift table with umlauts
+smpp.registerGsmCoder('GSM_DE', 0x05, {
+  chars:
+    '@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞ\x1BÆæßÉ !"#¤%&\'()*+,-./0123456789:;<=>?¡ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÑÜß¿abcdefghijklmnopqrstuvwxyzäöñüà',
+  extChars: '\f^{}\\[~]|€',
+  escChars: '\nΛ()/<=>¡e',
+  charRegex: /^[@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞ\x1BÆæßÉ !"#¤%&\'()*+,\-./0-9:;<=>?¡A-ZÄÖÑÜ߿a-zäöñüà\f^{}\\[~\]|€]*$/,
+  charListEnc: {},
+  extCharListEnc: {},
+  charListDec: {},
+  extCharListDec: {}
+});
+
+// Add to constants
+smpp.consts.ENCODING.GSM_DE = 0x01;
+```
+
+## Built-in Encodings
+
+The library comes with the following built-in encodings:
+
+### Standard Encodings
+
+| Name | Data Coding | Description |
+|------|-------------|-------------|
+| `ASCII` | 0x00 | GSM 03.38 default alphabet |
+| `LATIN1` | 0x03 | ISO-8859-1 (Latin-1) |
+| `UCS2` | 0x08 | Unicode 16-bit (UTF-16BE) |
+
+### GSM Shift Tables
+
+| Name | UDH Value | Description |
+|------|-----------|-------------|
+| `GSM` | 0x00 | GSM 03.38 standard |
+| `GSM_TR` | 0x01 | Turkish shift table |
+| `GSM_ES` | 0x02 | Spanish shift table |
+| `GSM_PT` | 0x03 | Portuguese shift table |
+
+## Examples
+
+### Example 1: Auto-detection with Custom Encoding
+
+```javascript
+const smpp = require('smpp');
+
+// Register custom encoding
+smpp.registerEncoding('CUSTOM', {
+  match: (value) => {
+    // Custom logic to detect if this encoding should be used
+    return /^[a-zA-Z0-9\s]+$/.test(value);
+  },
+  encode: (value) => {
+    return Buffer.from(value.toUpperCase(), 'ascii');
+  },
+  decode: (value) => {
+    return value.toString('ascii');
+  }
+});
+
+// Send message with automatic encoding detection
+session.submit_sm({
+  destination_addr: '1234567890',
+  short_message: 'Hello World',
+  data_coding: null // Auto-detect encoding
+}, (pdu) => {
+  console.log('Message sent with encoding:', pdu.data_coding);
+});
+```
+
+### Example 2: Changing Default Encoding
+
+```javascript
+const smpp = require('smpp');
+
+// Register UTF-8
+smpp.registerEncoding('UTF8', {
+  match: (value) => true,
+  encode: (value) => Buffer.from(value, 'utf8'),
+  decode: (value) => value.toString('utf8')
+});
+
+// Set UTF-8 as default
+smpp.encodings.default = 'UTF8';
+
+// Now all messages will use UTF-8 by default
+session.submit_sm({
+  destination_addr: '1234567890',
+  short_message: 'Hello 世界',
+  data_coding: null // Will use UTF8
+}, (pdu) => {
+  console.log('Message sent');
+});
+```
+
+### Example 3: Multiple Custom Encodings
+
+```javascript
+const smpp = require('smpp');
+const iconv = require('iconv-lite');
+
+// Register multiple custom encodings
+const customEncodings = {
+  'CP1251': 'windows-1251', // Cyrillic
+  'CP1252': 'windows-1252', // Western European
+  'CP1256': 'windows-1256', // Arabic
+  'SHIFT_JIS': 'shift_jis'  // Japanese
+};
+
+Object.entries(customEncodings).forEach(([name, iconvName]) => {
+  smpp.registerEncoding(name, {
+    match: (value) => {
+      try {
+        return value === iconv.decode(iconv.encode(value, iconvName), iconvName);
+      } catch (e) {
+        return false;
+      }
+    },
+    encode: (value) => iconv.encode(value, iconvName),
+    decode: (value) => iconv.decode(value, iconvName)
+  });
+
+  // Add to constants
+  smpp.consts.ENCODING[name] = 0x10 + Object.keys(customEncodings).indexOf(name);
+});
+```
+
+### Example 4: Custom Encoding with Validation
+
+```javascript
+const smpp = require('smpp');
+
+// Register encoding with validation
+smpp.registerEncoding('SAFE_ASCII', {
+  match: (value) => {
+    // Only allow safe ASCII characters
+    return /^[\x20-\x7E]*$/.test(value);
+  },
+  encode: (value) => {
+    // Remove unsafe characters before encoding
+    const safe = value.replace(/[^\x20-\x7E]/g, '?');
+    return Buffer.from(safe, 'ascii');
+  },
+  decode: (value) => {
+    return value.toString('ascii');
+  }
+});
+
+// Use with automatic fallback
+smpp.encodings.default = 'SAFE_ASCII';
+```
+
+## TypeScript Support
+
+The library includes full TypeScript support for custom encodings:
+
+```typescript
+import smpp, { Encoding, GsmCoderDefinition } from 'smpp';
+
+// Type-safe encoding registration
+const myEncoding: Encoding = {
+  match: (value: string): boolean => {
+    return true;
+  },
+  encode: (value: string): Buffer => {
+    return Buffer.from(value, 'utf8');
+  },
+  decode: (value: Buffer | string): string => {
+    if (Buffer.isBuffer(value)) {
+      return value.toString('utf8');
+    }
+    return String(value);
+  }
+};
+
+smpp.registerEncoding('MY_ENCODING', myEncoding);
+
+// Type-safe GSM coder registration
+const myGsmCoder: GsmCoderDefinition = {
+  chars: '...',
+  extChars: '...',
+  escChars: '...',
+  charRegex: /^.+$/,
+  charListEnc: {},
+  extCharListEnc: {},
+  charListDec: {},
+  extCharListDec: {}
+};
+
+smpp.registerGsmCoder('MY_GSM', 0x04, myGsmCoder);
+```
+
+## Advanced Usage
+
+### Encoding Priority
+
+When using auto-detection (`data_coding: null`), encodings are tested in the order they were registered. The first matching encoding is used. To ensure correct priority:
+
+```javascript
+// Register in order of specificity (most specific first)
+smpp.registerEncoding('CUSTOM_SPECIFIC', specificEncoding);
+smpp.registerEncoding('CUSTOM_GENERAL', generalEncoding);
+```
+
+### Removing Encodings
+
+You can remove built-in or custom encodings:
+
+```javascript
+// Remove an encoding
+delete smpp.encodings.LATIN1;
+
+// Replace an encoding
+smpp.encodings.ASCII = myCustomAsciiEncoding;
+```
+
+### UDH Integration
+
+Custom GSM coders work seamlessly with UDH (User Data Header):
+
+```javascript
+// The library automatically detects UDH language shift indicators
+// 0x24 = single shift
+// 0x25 = locking shift
+
+session.submit_sm({
+  destination_addr: '1234567890',
+  short_message: {
+    message: 'Custom message',
+    udh: Buffer.from([0x25, 0x01, 0x04]) // Locking shift to encoding 0x04
+  },
+  data_coding: 0x00
+});
+```
+
+## Troubleshooting
+
+### Encoding Not Detected
+
+If your custom encoding is not being auto-detected:
+
+1. Ensure `match()` returns `true` for the expected input
+2. Check the registration order - more specific encodings should be registered first
+3. Verify the encoding is not being overridden by a later registration
+
+### Character Corruption
+
+If characters are corrupted:
+
+1. Verify the `encode()` and `decode()` functions are inverse operations
+2. Check that `charRegex` matches all valid characters
+3. Ensure extended characters are properly mapped in GSM coders
+
+### TypeScript Errors
+
+If you encounter TypeScript errors:
+
+1. Ensure you're importing the types: `import { Encoding, GsmCoderDefinition } from 'smpp'`
+2. Check that all required interface methods are implemented
+3. Verify the function signatures match the interface definitions
+
+## Additional Resources
+
+- [SMPP 3.4 Specification](http://www.smsforum.net/SMPP_v3_4_Issue1_2.zip)
+- [GSM 03.38 Character Set](https://en.wikipedia.org/wiki/GSM_03.38)
+- [Node.js Buffer API](https://nodejs.org/api/buffer.html)
+- [iconv-lite for character encoding](https://github.com/ashtuchkin/iconv-lite)
+
+## Contributing
+
+If you create a useful custom encoding or GSM coder, consider contributing it back to the library by opening a pull request on GitHub.

--- a/lib/defs.ts
+++ b/lib/defs.ts
@@ -1,6 +1,97 @@
 import iconv from 'iconv-lite';
 import { consts } from './consts';
 
+/**
+ * Interface for custom encoding implementations
+ */
+export interface Encoding {
+  /**
+   * Test if a value matches this encoding's character set
+   * @param value - The string to test
+   * @returns true if the value can be encoded with this encoding
+   */
+  match: (value: string) => boolean;
+
+  /**
+   * Encode a string to a buffer using this encoding
+   * @param value - The string to encode
+   * @returns The encoded buffer
+   */
+  encode: (value: string) => Buffer;
+
+  /**
+   * Decode a buffer to a string using this encoding
+   * @param value - The buffer to decode
+   * @returns The decoded string
+   */
+  decode: (value: Buffer | string) => string;
+}
+
+/**
+ * Interface for GSM coder definitions
+ */
+export interface GsmCoderDefinition {
+  /**
+   * Standard character set (128 characters)
+   */
+  chars: string;
+
+  /**
+   * Extended characters (escaped with 0x1B)
+   */
+  extChars?: string;
+
+  /**
+   * Extended characters for encoding (if different from extChars)
+   */
+  extCharsEnc?: string;
+
+  /**
+   * Extended characters for decoding (if different from extChars)
+   */
+  extCharsDec?: string;
+
+  /**
+   * Escape characters for encoding
+   */
+  escChars?: string;
+
+  /**
+   * Escape characters for encoding (if different from escChars)
+   */
+  escCharsEnc?: string;
+
+  /**
+   * Escape characters for decoding (if different from escChars)
+   */
+  escCharsDec?: string;
+
+  /**
+   * Regular expression to validate if a string can be encoded with this coder
+   */
+  charRegex: RegExp;
+
+  /**
+   * Character lookup table for encoding (initialized lazily)
+   */
+  charListEnc: { [key: string]: number };
+
+  /**
+   * Extended character lookup table for encoding (initialized lazily)
+   */
+  extCharListEnc: { [key: string]: string };
+
+  /**
+   * Character lookup table for decoding (initialized lazily)
+   */
+  charListDec: { [key: number]: string };
+
+  /**
+   * Extended character lookup table for decoding (initialized lazily)
+   */
+  extCharListDec: { [key: string]: string };
+}
+
 const int8 = {
   read: function (buffer, offset) {
     return buffer.readUInt8(offset);
@@ -241,7 +332,17 @@ const types = {
   },
 } as const;
 
-const gsmCoder = {
+const gsmCoder: {
+  [key: string]: any;
+  GSM: GsmCoderDefinition;
+  GSM_TR: GsmCoderDefinition;
+  GSM_ES: GsmCoderDefinition;
+  GSM_PT: GsmCoderDefinition;
+  encode: (string: string, encoding: number) => Buffer;
+  decode: (string: Buffer | string, encoding: number) => string;
+  getCoder: (encoding: number) => GsmCoderDefinition;
+  detect: (string: string) => number | undefined;
+} = {
   // GSM 03.38
   GSM: {
     chars:
@@ -383,9 +484,16 @@ const gsmCoder = {
 
     return undefined;
   },
-} as const;
+};
 
-const encodings = {
+const encodings: {
+  [key: string]: any;
+  ASCII: Encoding;
+  LATIN1: Encoding;
+  UCS2: Encoding;
+  default: string;
+  detect: (value: string) => string | false;
+} = {
   ASCII: {
     // GSM 03.38
     match: function (value) {
@@ -406,6 +514,9 @@ const encodings = {
       return iconv.encode(value, 'latin1');
     },
     decode: function (value) {
+      if (typeof value === 'string') {
+        value = Buffer.from(value, 'latin1');
+      }
       return iconv.decode(value, 'latin1');
     },
   },
@@ -417,20 +528,23 @@ const encodings = {
       return iconv.encode(value, 'utf16-be');
     },
     decode: function (value) {
+      if (typeof value === 'string') {
+        value = iconv.encode(value, 'utf16-be');
+      }
       return iconv.decode(value, 'utf16-be');
     },
   },
   default: 'ASCII' as string,
   detect: function (value) {
     for (const key in encodings) {
-      if (encodings[key].match(value)) {
+      if (encodings[key].match && encodings[key].match(value)) {
         return key;
       }
     }
 
     return false;
   },
-} as const;
+};
 
 const udhCoder = {
   getUdh: function (buffer: Buffer): Array<any> {
@@ -736,6 +850,160 @@ const filters = {
     },
   },
 } as const;
+
+/**
+ * Register a custom encoding
+ *
+ * @param name - The name of the encoding (e.g., 'UTF8', 'CUSTOM')
+ * @param encoding - The encoding implementation
+ *
+ * @example
+ * ```typescript
+ * import smpp from 'smpp';
+ *
+ * // Register a custom UTF-8 encoding
+ * smpp.registerEncoding('UTF8', {
+ *   match: (value) => {
+ *     // Check if value can be encoded as UTF-8
+ *     return Buffer.byteLength(value, 'utf8') === value.length;
+ *   },
+ *   encode: (value) => {
+ *     return Buffer.from(value, 'utf8');
+ *   },
+ *   decode: (value) => {
+ *     return value.toString('utf8');
+ *   }
+ * });
+ *
+ * // Set as default encoding
+ * smpp.encodings.default = 'UTF8';
+ * ```
+ */
+export function registerEncoding(name: string, encoding: Encoding): void {
+  if (!name || typeof name !== 'string') {
+    throw new Error('Encoding name must be a non-empty string');
+  }
+
+  if (!encoding || typeof encoding !== 'object') {
+    throw new Error('Encoding must be an object');
+  }
+
+  if (typeof encoding.match !== 'function') {
+    throw new Error('Encoding must have a match() function');
+  }
+
+  if (typeof encoding.encode !== 'function') {
+    throw new Error('Encoding must have an encode() function');
+  }
+
+  if (typeof encoding.decode !== 'function') {
+    throw new Error('Encoding must have a decode() function');
+  }
+
+  encodings[name] = encoding;
+}
+
+/**
+ * Register a custom GSM coder
+ *
+ * @param name - The name of the GSM coder (e.g., 'GSM_FR', 'GSM_DE')
+ * @param encodingValue - The encoding value (0x00-0xFF) used in UDH headers
+ * @param coderDef - The GSM coder definition
+ *
+ * @example
+ * ```typescript
+ * import smpp from 'smpp';
+ *
+ * // Register a custom GSM French shift table
+ * smpp.registerGsmCoder('GSM_FR', 0x04, {
+ *   chars: '@£$¥èéùìòÇ\nØø\rÅå...', // 128 standard characters
+ *   extChars: '\f^{}[~]|€',          // Extended characters
+ *   escChars: '\nΛ()/<=>¡e',          // Escape characters
+ *   charRegex: /^[...]*$/,            // Validation regex
+ *   charListEnc: {},
+ *   extCharListEnc: {},
+ *   charListDec: {},
+ *   extCharListDec: {}
+ * });
+ * ```
+ */
+export function registerGsmCoder(
+  name: string,
+  encodingValue: number,
+  coderDef: GsmCoderDefinition
+): void {
+  if (!name || typeof name !== 'string') {
+    throw new Error('GSM coder name must be a non-empty string');
+  }
+
+  if (typeof encodingValue !== 'number' || encodingValue < 0 || encodingValue > 255) {
+    throw new Error('Encoding value must be a number between 0 and 255');
+  }
+
+  if (!coderDef || typeof coderDef !== 'object') {
+    throw new Error('GSM coder definition must be an object');
+  }
+
+  if (typeof coderDef.chars !== 'string') {
+    throw new Error('GSM coder must have a chars string');
+  }
+
+  if (!(coderDef.charRegex instanceof RegExp)) {
+    throw new Error('GSM coder must have a charRegex RegExp');
+  }
+
+  // Initialize lookup tables if not provided
+  if (!coderDef.charListEnc) {
+    coderDef.charListEnc = {};
+  }
+  if (!coderDef.extCharListEnc) {
+    coderDef.extCharListEnc = {};
+  }
+  if (!coderDef.charListDec) {
+    coderDef.charListDec = {};
+  }
+  if (!coderDef.extCharListDec) {
+    coderDef.extCharListDec = {};
+  }
+
+  // Add to gsmCoder
+  gsmCoder[name] = coderDef;
+
+  // Update getCoder to handle this encoding value
+  const originalGetCoder = gsmCoder.getCoder;
+  gsmCoder.getCoder = function (encoding: number) {
+    if (encoding === encodingValue) {
+      const coder = gsmCoder[name];
+
+      // Lazy initialization of lookup tables
+      if (Object.keys(coder.charListEnc).length === 0) {
+        for (var i = 0; i < coder.chars.length; i++) {
+          coder.charListEnc[coder.chars[i]] = i;
+          coder.charListDec[i] = coder.chars[i];
+        }
+
+        const extCharsEnc = coder.extCharsEnc || coder.extChars;
+        const escCharsEnc = coder.escCharsEnc || coder.escChars;
+        if (extCharsEnc && escCharsEnc) {
+          for (var i = 0; i < extCharsEnc.length; i++) {
+            coder.extCharListEnc[extCharsEnc[i]] = escCharsEnc[i];
+          }
+        }
+
+        const extCharsDec = coder.extCharsDec || coder.extChars;
+        const escCharsDec = coder.escCharsDec || coder.escChars;
+        if (extCharsDec && escCharsDec) {
+          for (var i = 0; i < escCharsDec.length; i++) {
+            coder.extCharListDec[escCharsDec[i]] = extCharsDec[i];
+          }
+        }
+      }
+
+      return coder;
+    }
+    return originalGetCoder.call(this, encoding);
+  };
+}
 
 export { errors } from './errors';
 export { encodings };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "smpp",
+  "name": "@semyonf/smpp",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "smpp",
+      "name": "@semyonf/smpp",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/test/encoding-extensions.js
+++ b/test/encoding-extensions.js
@@ -1,0 +1,448 @@
+const assert = require('assert');
+const smpp = require('..');
+
+describe('Encoding Extensions', function () {
+  describe('registerEncoding()', function () {
+    it('should register a custom encoding', function () {
+      const customEncoding = {
+        match: (value) => /^[A-Z]+$/.test(value),
+        encode: (value) => Buffer.from(value, 'ascii'),
+        decode: (value) => value.toString('ascii'),
+      };
+
+      smpp.registerEncoding('UPPERCASE', customEncoding);
+
+      assert.ok(smpp.encodings.UPPERCASE);
+      assert.strictEqual(typeof smpp.encodings.UPPERCASE.match, 'function');
+      assert.strictEqual(typeof smpp.encodings.UPPERCASE.encode, 'function');
+      assert.strictEqual(typeof smpp.encodings.UPPERCASE.decode, 'function');
+    });
+
+    it('should use custom encoding for encoding', function () {
+      const customEncoding = {
+        match: (value) => true,
+        encode: (value) => Buffer.from(value.toUpperCase(), 'ascii'),
+        decode: (value) => value.toString('ascii').toLowerCase(),
+      };
+
+      smpp.registerEncoding('UPPER_LOWER', customEncoding);
+
+      const encoded = smpp.encodings.UPPER_LOWER.encode('hello');
+      assert.ok(Buffer.isBuffer(encoded));
+      assert.strictEqual(encoded.toString('ascii'), 'HELLO');
+
+      const decoded = smpp.encodings.UPPER_LOWER.decode(encoded);
+      assert.strictEqual(decoded, 'hello');
+    });
+
+    it('should detect custom encoding', function () {
+      const customEncoding = {
+        match: (value) => /^\d+$/.test(value),
+        encode: (value) => Buffer.from(value, 'ascii'),
+        decode: (value) => value.toString('ascii'),
+      };
+
+      smpp.registerEncoding('DIGITS_ONLY', customEncoding);
+
+      assert.ok(smpp.encodings.DIGITS_ONLY.match('12345'));
+      assert.ok(!smpp.encodings.DIGITS_ONLY.match('abc123'));
+    });
+
+    it('should throw error for invalid encoding name', function () {
+      assert.throws(
+        () => {
+          smpp.registerEncoding('', {
+            match: () => true,
+            encode: () => Buffer.alloc(0),
+            decode: () => '',
+          });
+        },
+        /Encoding name must be a non-empty string/
+      );
+
+      assert.throws(
+        () => {
+          smpp.registerEncoding(null, {
+            match: () => true,
+            encode: () => Buffer.alloc(0),
+            decode: () => '',
+          });
+        },
+        /Encoding name must be a non-empty string/
+      );
+    });
+
+    it('should throw error for invalid encoding object', function () {
+      assert.throws(
+        () => {
+          smpp.registerEncoding('TEST', null);
+        },
+        /Encoding must be an object/
+      );
+
+      assert.throws(
+        () => {
+          smpp.registerEncoding('TEST', 'not an object');
+        },
+        /Encoding must be an object/
+      );
+    });
+
+    it('should throw error for missing match function', function () {
+      assert.throws(
+        () => {
+          smpp.registerEncoding('TEST', {
+            encode: () => Buffer.alloc(0),
+            decode: () => '',
+          });
+        },
+        /Encoding must have a match\(\) function/
+      );
+    });
+
+    it('should throw error for missing encode function', function () {
+      assert.throws(
+        () => {
+          smpp.registerEncoding('TEST', {
+            match: () => true,
+            decode: () => '',
+          });
+        },
+        /Encoding must have an encode\(\) function/
+      );
+    });
+
+    it('should throw error for missing decode function', function () {
+      assert.throws(
+        () => {
+          smpp.registerEncoding('TEST', {
+            match: () => true,
+            encode: () => Buffer.alloc(0),
+          });
+        },
+        /Encoding must have a decode\(\) function/
+      );
+    });
+
+    it('should allow overriding existing encodings', function () {
+      const originalAscii = smpp.encodings.ASCII;
+
+      const customAscii = {
+        match: (value) => true,
+        encode: (value) => Buffer.from('CUSTOM', 'ascii'),
+        decode: (value) => 'CUSTOM',
+      };
+
+      smpp.registerEncoding('ASCII', customAscii);
+
+      assert.strictEqual(smpp.encodings.ASCII.encode('test').toString('ascii'), 'CUSTOM');
+      assert.strictEqual(smpp.encodings.ASCII.decode(Buffer.from('test')), 'CUSTOM');
+
+      // Restore original
+      smpp.encodings.ASCII = originalAscii;
+    });
+
+    it('should work with UTF-8 encoding', function () {
+      const utf8Encoding = {
+        match: (value) => true,
+        encode: (value) => Buffer.from(value, 'utf8'),
+        decode: (value) => {
+          if (Buffer.isBuffer(value)) {
+            return value.toString('utf8');
+          }
+          return String(value);
+        },
+      };
+
+      smpp.registerEncoding('UTF8', utf8Encoding);
+
+      const testString = 'Hello 世界 🌍';
+      const encoded = smpp.encodings.UTF8.encode(testString);
+      const decoded = smpp.encodings.UTF8.decode(encoded);
+
+      assert.strictEqual(decoded, testString);
+    });
+  });
+
+  describe('registerGsmCoder()', function () {
+    it('should register a custom GSM coder', function () {
+      const customCoder = {
+        chars:
+          '@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞ\x1BÆæßÉ !"#¤%&\'()*+,-./0123456789:;<=>?¡ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÑÜ§¿abcdefghijklmnopqrstuvwxyzäöñüà',
+        extChars: '\f^{}\\\\[~]|€',
+        escChars: '\nΛ()\\/<=>¡e',
+        charRegex: /^[@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞ\x1BÆæßÉ !"#¤%&\'()*+,\-./0-9:;<=>?¡A-ZÄÖÑÜ§¿a-zäöñüà\f^{}\\[~\]|€]*$/,
+        charListEnc: {},
+        extCharListEnc: {},
+        charListDec: {},
+        extCharListDec: {},
+      };
+
+      smpp.registerGsmCoder('GSM_CUSTOM', 0x10, customCoder);
+
+      assert.ok(smpp.gsmCoder.GSM_CUSTOM);
+      assert.strictEqual(smpp.gsmCoder.GSM_CUSTOM.chars, customCoder.chars);
+    });
+
+    it('should use custom GSM coder for encoding', function () {
+      const customCoder = {
+        chars:
+          '@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞ\x1BÆæßÉ !"#¤%&\'()*+,-./0123456789:;<=>?¡ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÑÜ§¿abcdefghijklmnopqrstuvwxyzäöñüà',
+        extChars: '\f^{}\\\\[~]|€',
+        escChars: '\nΛ()\\/<=>¡e',
+        charRegex: /^[@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞ\x1BÆæßÉ !"#¤%&\'()*+,\-./0-9:;<=>?¡A-ZÄÖÑÜ§¿a-zäöñüà\f^{}\\[~\]|€]*$/,
+        charListEnc: {},
+        extCharListEnc: {},
+        charListDec: {},
+        extCharListDec: {},
+      };
+
+      smpp.registerGsmCoder('GSM_TEST', 0x11, customCoder);
+
+      const encoded = smpp.gsmCoder.encode('Hello', 0x11);
+      assert.ok(Buffer.isBuffer(encoded));
+      assert.ok(encoded.length > 0);
+
+      const decoded = smpp.gsmCoder.decode(encoded, 0x11);
+      assert.strictEqual(decoded, 'Hello');
+    });
+
+    it('should initialize lookup tables lazily', function () {
+      const customCoder = {
+        chars:
+          '@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞ\x1BÆæßÉ !"#¤%&\'()*+,-./0123456789:;<=>?¡ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÑÜ§¿abcdefghijklmnopqrstuvwxyzäöñüà',
+        extChars: '\f^{}\\\\[~]|€',
+        escChars: '\nΛ()\\/<=>¡e',
+        charRegex: /^[@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞ\x1BÆæßÉ !"#¤%&\'()*+,\-./0-9:;<=>?¡A-ZÄÖÑÜ§¿a-zäöñüà\f^{}\\[~\]|€]*$/,
+        charListEnc: {},
+        extCharListEnc: {},
+        charListDec: {},
+        extCharListDec: {},
+      };
+
+      smpp.registerGsmCoder('GSM_LAZY', 0x12, customCoder);
+
+      // Lookup tables should be empty
+      assert.strictEqual(Object.keys(smpp.gsmCoder.GSM_LAZY.charListEnc).length, 0);
+
+      // Trigger initialization by encoding
+      smpp.gsmCoder.encode('A', 0x12);
+
+      // Lookup tables should now be populated
+      assert.ok(Object.keys(smpp.gsmCoder.GSM_LAZY.charListEnc).length > 0);
+    });
+
+    it('should throw error for invalid GSM coder name', function () {
+      assert.throws(
+        () => {
+          smpp.registerGsmCoder('', 0x10, {
+            chars: 'test',
+            charRegex: /test/,
+            charListEnc: {},
+            extCharListEnc: {},
+            charListDec: {},
+            extCharListDec: {},
+          });
+        },
+        /GSM coder name must be a non-empty string/
+      );
+    });
+
+    it('should throw error for invalid encoding value', function () {
+      assert.throws(
+        () => {
+          smpp.registerGsmCoder('TEST', -1, {
+            chars: 'test',
+            charRegex: /test/,
+            charListEnc: {},
+            extCharListEnc: {},
+            charListDec: {},
+            extCharListDec: {},
+          });
+        },
+        /Encoding value must be a number between 0 and 255/
+      );
+
+      assert.throws(
+        () => {
+          smpp.registerGsmCoder('TEST', 256, {
+            chars: 'test',
+            charRegex: /test/,
+            charListEnc: {},
+            extCharListEnc: {},
+            charListDec: {},
+            extCharListDec: {},
+          });
+        },
+        /Encoding value must be a number between 0 and 255/
+      );
+    });
+
+    it('should throw error for invalid GSM coder definition', function () {
+      assert.throws(
+        () => {
+          smpp.registerGsmCoder('TEST', 0x10, null);
+        },
+        /GSM coder definition must be an object/
+      );
+    });
+
+    it('should throw error for missing chars property', function () {
+      assert.throws(
+        () => {
+          smpp.registerGsmCoder('TEST', 0x10, {
+            charRegex: /test/,
+            charListEnc: {},
+            extCharListEnc: {},
+            charListDec: {},
+            extCharListDec: {},
+          });
+        },
+        /GSM coder must have a chars string/
+      );
+    });
+
+    it('should throw error for missing charRegex property', function () {
+      assert.throws(
+        () => {
+          smpp.registerGsmCoder('TEST', 0x10, {
+            chars: 'test',
+            charListEnc: {},
+            extCharListEnc: {},
+            charListDec: {},
+            extCharListDec: {},
+          });
+        },
+        /GSM coder must have a charRegex RegExp/
+      );
+    });
+
+    it('should handle extended characters correctly', function () {
+      const customCoder = {
+        chars:
+          '@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞ\x1BÆæßÉ !"#¤%&\'()*+,-./0123456789:;<=>?¡ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÑÜ§¿abcdefghijklmnopqrstuvwxyzäöñüà',
+        extChars: '\f^{}\\\\[~]|€',
+        escChars: '\nΛ()\\/<=>¡e',
+        charRegex: /^[@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞ\x1BÆæßÉ !"#¤%&\'()*+,\-./0-9:;<=>?¡A-ZÄÖÑÜ§¿a-zäöñüà\f^{}\\[~\]|€]*$/,
+        charListEnc: {},
+        extCharListEnc: {},
+        charListDec: {},
+        extCharListDec: {},
+      };
+
+      smpp.registerGsmCoder('GSM_EXT', 0x13, customCoder);
+
+      // Test with extended character (€)
+      const testString = 'Test€';
+      const encoded = smpp.gsmCoder.encode(testString, 0x13);
+      const decoded = smpp.gsmCoder.decode(encoded, 0x13);
+
+      assert.strictEqual(decoded, testString);
+    });
+
+    it('should work with getCoder', function () {
+      const customCoder = {
+        chars:
+          '@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞ\x1BÆæßÉ !"#¤%&\'()*+,-./0123456789:;<=>?¡ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÑÜ§¿abcdefghijklmnopqrstuvwxyzäöñüà',
+        extChars: '\f^{}\\\\[~]|€',
+        escChars: '\nΛ()\\/<=>¡e',
+        charRegex: /^[@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞ\x1BÆæßÉ !"#¤%&\'()*+,\-./0-9:;<=>?¡A-ZÄÖÑÜ§¿a-zäöñüà\f^{}\\[~\]|€]*$/,
+        charListEnc: {},
+        extCharListEnc: {},
+        charListDec: {},
+        extCharListDec: {},
+      };
+
+      smpp.registerGsmCoder('GSM_GETCODER', 0x14, customCoder);
+
+      const coder = smpp.gsmCoder.getCoder(0x14);
+      assert.ok(coder);
+      assert.strictEqual(coder.chars, customCoder.chars);
+    });
+
+    it('should initialize lookup tables if not provided', function () {
+      const customCoder = {
+        chars: 'ABC',
+        charRegex: /^[ABC]*$/,
+        // Don't provide lookup tables
+      };
+
+      smpp.registerGsmCoder('GSM_AUTO', 0x15, customCoder);
+
+      // Lookup tables should be initialized
+      assert.ok(smpp.gsmCoder.GSM_AUTO.charListEnc);
+      assert.ok(smpp.gsmCoder.GSM_AUTO.extCharListEnc);
+      assert.ok(smpp.gsmCoder.GSM_AUTO.charListDec);
+      assert.ok(smpp.gsmCoder.GSM_AUTO.extCharListDec);
+    });
+  });
+
+  describe('Integration tests', function () {
+    it('should use custom encoding in message filter', function () {
+      // Register a simple custom encoding
+      smpp.registerEncoding('SIMPLE', {
+        match: (value) => /^[a-z]+$/.test(value),
+        encode: (value) => Buffer.from(value, 'ascii'),
+        decode: (value) => value.toString('ascii'),
+      });
+
+      // Add to constants
+      smpp.consts.ENCODING.SIMPLE = 0x20;
+
+      // Test encoding through filter
+      const context = { data_coding: 0x20 };
+      const encoded = smpp.filters.message.encode.call(context, 'hello');
+
+      assert.ok(Buffer.isBuffer(encoded));
+      assert.strictEqual(encoded.toString('ascii'), 'hello');
+    });
+
+    it('should use custom encoding with auto-detection', function () {
+      // Register encoding that matches numbers
+      smpp.registerEncoding('NUMBERS', {
+        match: (value) => /^\d+$/.test(value),
+        encode: (value) => Buffer.from('NUM:' + value, 'ascii'),
+        decode: (value) => value.toString('ascii').replace('NUM:', ''),
+      });
+
+      // The encoding should be detected
+      assert.ok(smpp.encodings.NUMBERS.match('12345'));
+      assert.ok(!smpp.encodings.NUMBERS.match('abc'));
+    });
+
+    it('should handle multiple custom encodings', function () {
+      const encodings = [
+        {
+          name: 'ALPHA',
+          match: (v) => /^[a-zA-Z]+$/.test(v),
+          encode: (v) => Buffer.from(v, 'ascii'),
+          decode: (v) => v.toString('ascii'),
+        },
+        {
+          name: 'NUMERIC',
+          match: (v) => /^\d+$/.test(v),
+          encode: (v) => Buffer.from(v, 'ascii'),
+          decode: (v) => v.toString('ascii'),
+        },
+        {
+          name: 'ALPHANUMERIC',
+          match: (v) => /^[a-zA-Z0-9]+$/.test(v),
+          encode: (v) => Buffer.from(v, 'ascii'),
+          decode: (v) => v.toString('ascii'),
+        },
+      ];
+
+      encodings.forEach((enc) => {
+        smpp.registerEncoding(enc.name, {
+          match: enc.match,
+          encode: enc.encode,
+          decode: enc.decode,
+        });
+      });
+
+      assert.ok(smpp.encodings.ALPHA);
+      assert.ok(smpp.encodings.NUMERIC);
+      assert.ok(smpp.encodings.ALPHANUMERIC);
+    });
+  });
+});


### PR DESCRIPTION
implemented a comprehensive mechanism to extend the node-smpp library with custom data codings. All changes have been committed to branch claude/extend-mechanism-011CV4dgfsonxBVAEPpcWLNp and pushed to the remote repository.
What was delivered:
Two powerful extension APIs:
registerEncoding() - for custom character encodings (UTF-8, ISO-8859-2, etc.)
registerGsmCoder() - for custom GSM 03.38 shift tables (language-specific)
Full TypeScript support:
Encoding interface
GsmCoderDefinition interface
Comprehensive documentation:
ENCODINGS.md with examples and usage guide
Complete test coverage:
24 tests covering all functionality
All tests passing ✅
The implementation is production-ready and allows users to easily extend the library with any custom data coding they need!